### PR TITLE
[FIX] Add wait for initial page load for create event page

### DIFF
--- a/src/test/java/com/team25/event/planner/pages/CreateEventPage.java
+++ b/src/test/java/com/team25/event/planner/pages/CreateEventPage.java
@@ -123,4 +123,8 @@ public class CreateEventPage {
         wait.until(ExpectedConditions.presenceOfElementLocated(invitationCloseButton));
         driver.findElement(invitationCloseButton).click();
     }
+
+    public By getInitiallyPresentElement() {
+        return nameField;
+    }
 }

--- a/src/test/java/com/team25/event/planner/tests/CreateEventTest.java
+++ b/src/test/java/com/team25/event/planner/tests/CreateEventTest.java
@@ -29,6 +29,8 @@ public class CreateEventTest extends BaseTest {
         driver.get(Constants.CREATE_EVENT_URL);
         CreateEventPage createEventPage = new CreateEventPage(driver);
 
+        waitForElementToBePresent(createEventPage.getInitiallyPresentElement());
+
         // Fill in the form
         createEventPage.enterName("New Event");
         createEventPage.selectEventType("Conference");
@@ -117,6 +119,8 @@ public class CreateEventTest extends BaseTest {
         driver.get(Constants.CREATE_EVENT_URL);
         CreateEventPage createEventPage = new CreateEventPage(driver);
 
+        waitForElementToBePresent(createEventPage.getInitiallyPresentElement());
+
         // Click into required fields to make them dirty
         createEventPage.enterName("");
         createEventPage.enterCity("");
@@ -136,6 +140,8 @@ public class CreateEventTest extends BaseTest {
     public void testCreateEventWithInvalidDates() {
         driver.get(Constants.CREATE_EVENT_URL);
         CreateEventPage createEventPage = new CreateEventPage(driver);
+
+        waitForElementToBePresent(createEventPage.getInitiallyPresentElement());
 
         createEventPage.enterName("Invalid Date Event");
         createEventPage.selectEventType("Conference");
@@ -162,6 +168,8 @@ public class CreateEventTest extends BaseTest {
     public void testCreateEventWithoutParticipantsLimitNoAgenda() {
         driver.get(Constants.CREATE_EVENT_URL);
         CreateEventPage createEventPage = new CreateEventPage(driver);
+
+        waitForElementToBePresent(createEventPage.getInitiallyPresentElement());
 
         createEventPage.enterName("No Participants Limit Event");
         createEventPage.selectEventType("Conference");
@@ -211,6 +219,8 @@ public class CreateEventTest extends BaseTest {
     public void testCreatePrivateEvent() {
         driver.get(Constants.CREATE_EVENT_URL);
         CreateEventPage createEventPage = new CreateEventPage(driver);
+
+        waitForElementToBePresent(createEventPage.getInitiallyPresentElement());
 
         createEventPage.enterName("Private Event");
         createEventPage.selectEventType("Conference");


### PR DESCRIPTION
Added an explicit wait for an element on `CreateEventPage` to the start of all tests to avoid `NoSuchElementException` at the beginning tests.